### PR TITLE
chore: simplified eslint.config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,21 +3,17 @@ import {fileURLToPath} from "node:url"
 
 import {includeIgnoreFile} from "@eslint/compat"
 import js from "@eslint/js"
-import prettier from "eslint-config-prettier"
 import jsxA11y from "eslint-plugin-jsx-a11y"
 import react from "eslint-plugin-react"
 import reactHooks from "eslint-plugin-react-hooks"
 import simpleImportSort from "eslint-plugin-simple-import-sort"
-import globals from "globals"
 import ts from "typescript-eslint"
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 const gitignore = path.resolve(dirname, ".gitignore")
 
-/** @type {import('eslint').Linter.Config[]} */
-
-const config = [
+export default ts.config(
     includeIgnoreFile(gitignore),
     {
         files: [
@@ -30,16 +26,7 @@ const config = [
             "**/*.mts",
             "**/*.tsx",
         ],
-
         languageOptions: {
-            ecmaVersion: "latest",
-            globals: {
-                ...globals.browser,
-                ...globals.node,
-                ...globals.es2025,
-                ...globals.jest,
-            },
-            parser: ts.parser,
             parserOptions: {
                 projectService: true,
                 tsconfigRootDir: import.meta.dirname,
@@ -56,11 +43,10 @@ const config = [
         },
     },
     js.configs.recommended,
-    ...ts.configs.recommended,
+    ts.configs.recommended,
     react.configs.flat.recommended,
     react.configs.flat["jsx-runtime"],
     jsxA11y.flatConfigs.recommended,
-    prettier,
     {
         rules: {
             ...reactHooks.configs.recommended.rules,
@@ -72,12 +58,7 @@ const config = [
                     fixStyle: "separate-type-imports",
                 },
             ],
-            "@typescript-eslint/consistent-type-exports": [
-                "error",
-                {
-                    fixMixedExportsWithInlineTypeSpecifier: false,
-                },
-            ],
+            "@typescript-eslint/consistent-type-exports": "error",
             "@typescript-eslint/no-import-type-side-effects": "error",
             "@typescript-eslint/no-unused-vars": [
                 "error",
@@ -85,74 +66,11 @@ const config = [
                     ignoreRestSiblings: true,
                 },
             ],
-            "comma-dangle": ["error", "always-multiline"],
-            "comma-spacing": [
-                "error",
-                {
-                    before: false,
-                    after: true,
-                },
-            ],
-            "comma-style": ["error", "last"],
-            "eol-last": ["error", "always"],
             "eqeqeq": ["error", "always"],
-            "function-paren-newline": ["off"],
-            "indent": ["off"],
-            "jsx-a11y/accessible-emoji": ["off"],
-            "no-console": ["off"],
-            "no-mixed-spaces-and-tabs": ["error"],
-            "no-unused-vars": [
-                "error",
-                {
-                    ignoreRestSiblings: true,
-                },
-            ],
-            "object-curly-newline": [
-                "error",
-                {
-                    consistent: true,
-                },
-            ],
-            "object-curly-spacing": ["error", "never"],
-            "object-property-newline": [
-                "error",
-                {
-                    allowAllPropertiesOnSameLine: true,
-                },
-            ],
-            "prefer-const": ["error"],
-            "quote-props": ["error", "consistent-as-needed"],
-            "quotes": ["error", "double"],
-            "react/jsx-tag-spacing": [
-                "error",
-                {
-                    beforeSelfClosing: "always",
-                },
-            ],
-            "react/react-in-jsx-scope": ["off"],
-            "react-hooks/rules-of-hooks": ["error"],
-            "react-hooks/exhaustive-deps": ["error"],
-            "semi": ["error", "never"],
-            "semi-spacing": [
-                "error",
-                {
-                    before: false,
-                    after: true,
-                },
-            ],
-            "semi-style": ["error", "last"],
-            "simple-import-sort/imports": ["error"],
-            "simple-import-sort/exports": ["error"],
-            "space-before-function-paren": [
-                "error",
-                {
-                    anonymous: "never",
-                    named: "never",
-                    asyncArrow: "always",
-                },
-            ],
+            "prefer-const": "error",
+            "react-hooks/exhaustive-deps": "error",
+            "simple-import-sort/imports": "error",
+            "simple-import-sort/exports": "error",
         },
     },
-]
-
-export default config
+)

--- a/src/hooks/useMarkdown/useMarkdown.test.tsx
+++ b/src/hooks/useMarkdown/useMarkdown.test.tsx
@@ -40,7 +40,6 @@ test("renders images", () => {
 
     const {result} = renderHook(() =>
         useMarkdown(
-            // eslint-disable-next-line quotes
             '<img src="https://bradgarropy.com/profile.jpg" alt="profile" width="100" height="100"/>',
         ),
     )

--- a/src/transformers/twitch/twitch.test.ts
+++ b/src/transformers/twitch/twitch.test.ts
@@ -63,6 +63,5 @@ test("transforms twitch clips", () => {
 
     const emptyHtml = twitchTransformer.getHTML("https://twitch.tv")
 
-    // eslint-disable-next-line quotes
     expect(emptyHtml).toEqual('<div class="twitch"></div>')
 })

--- a/src/transformers/twitch/twitch.ts
+++ b/src/transformers/twitch/twitch.ts
@@ -17,7 +17,6 @@ const getHTML = (string: string): string => {
     } else if (isClip(string)) {
         src = `https://clips.twitch.tv/embed?clip=${id}`
     } else {
-        // eslint-disable-next-line quotes
         const html = '<div class="twitch"></div>'
         return html
     }

--- a/src/transformers/twitter/twitter.test.ts
+++ b/src/transformers/twitter/twitter.test.ts
@@ -22,18 +22,15 @@ test("transforms twitter links", async () => {
     )
 
     expect(html).toEqual(
-        // eslint-disable-next-line quotes
         expect.stringContaining('<div class="grid justify-center">'),
     )
 
     expect(html).toEqual(
-        // eslint-disable-next-line quotes
         expect.stringContaining('<blockquote class="twitter-tweet">'),
     )
 
     expect(html).toEqual(
         expect.stringContaining(
-            // eslint-disable-next-line quotes
             '<script async src="https://platform.twitter.com/widgets.js" charset="utf-8">',
         ),
     )

--- a/src/utils/feed.test.ts
+++ b/src/utils/feed.test.ts
@@ -64,7 +64,6 @@ test("caches json feed", async () => {
 
     const feed = await generateFeed("json")
 
-    // eslint-disable-next-line quotes
     expect(feed).toContain('"title": "bradgarropy.com"')
     expect(feed).not.toBeUndefined()
 

--- a/src/utils/markdown.server.test.ts
+++ b/src/utils/markdown.server.test.ts
@@ -30,7 +30,6 @@ describe("transforms markdown", () => {
         )
 
         expect(html).toEqual(
-            // eslint-disable-next-line quotes
             '<a href="https://bradgarropy.com/profile.jpg"><img src="https://bradgarropy.com/profile.jpg" alt="brad garropy"></a>',
         )
     })
@@ -43,7 +42,6 @@ describe("transforms markdown", () => {
         )
 
         expect(html).toEqual(
-            // eslint-disable-next-line quotes
             '<a href="http://res.cloudinary.com/profile.jpg"><img src="http://res.cloudinary.com/profile.jpg" alt="brad garropy" width="100" height="100"></a>',
         )
 
@@ -52,7 +50,6 @@ describe("transforms markdown", () => {
         )
 
         expect(html).toEqual(
-            // eslint-disable-next-line quotes
             '<a href="https://res.cloudinary.com/profile.jpg"><img src="https://res.cloudinary.com/profile.jpg" alt="brad garropy" width="100" height="100"></a>',
         )
     })
@@ -63,7 +60,6 @@ describe("transforms markdown", () => {
         )
 
         expect(html).toEqual(
-            // eslint-disable-next-line quotes
             '<a href="https://bradgarropy.com/profile.jpg"><img src="https://bradgarropy.com/profile.jpg" alt="brad garropy"></a>',
         )
     })
@@ -74,7 +70,6 @@ describe("transforms markdown", () => {
         )
 
         expect(html).toEqual(
-            // eslint-disable-next-line quotes
             '<a href="https://res.cloudinary.com/bradgarropy/image/upload/bradgarropy.com/profile.jpg"><img src="https://res.cloudinary.com/bradgarropy/image/upload/f_auto,q_auto,w_660,c_limit/bradgarropy.com/profile.jpg" alt="brad garropy" width="100" height="100"></a>',
         )
     })
@@ -85,7 +80,6 @@ describe("transforms markdown", () => {
         )
 
         expect(html).toEqual(
-            // eslint-disable-next-line quotes
             '<a href="https://bradgarropy.com/profile.jpg"><img src="https://bradgarropy.com/profile.jpg" alt="brad garropy"></a>',
         )
     })
@@ -99,7 +93,6 @@ describe("transforms markdown", () => {
 
         expect(html).toEqual(
             expect.stringContaining(
-                // eslint-disable-next-line quotes
                 'src="https://codesandbox.io/embed/exciting-pascal-j5hwu"',
             ),
         )
@@ -112,7 +105,6 @@ describe("transforms markdown", () => {
 
         expect(html).toEqual(
             expect.stringContaining(
-                // eslint-disable-next-line quotes
                 'src="https://player.twitch.tv?channel=bradgarropy&#x26;parent=bradgarropy.com"',
             ),
         )
@@ -124,18 +116,15 @@ describe("transforms markdown", () => {
         )
 
         expect(html).toEqual(
-            // eslint-disable-next-line quotes
             expect.stringContaining('<div class="grid justify-center">'),
         )
 
         expect(html).toEqual(
-            // eslint-disable-next-line quotes
             expect.stringContaining('<blockquote class="twitter-tweet">'),
         )
 
         expect(html).toEqual(
             expect.stringContaining(
-                // eslint-disable-next-line quotes
                 '<script async src="https://platform.twitter.com/widgets.js" charset="utf-8">',
             ),
         )
@@ -146,12 +135,10 @@ describe("transforms markdown", () => {
 
         expect(html).toEqual(expect.stringContaining("<iframe"))
 
-        // eslint-disable-next-line quotes
         expect(html).toEqual(expect.stringContaining('title="9zcU6oUOHVc"'))
 
         expect(html).toEqual(
             expect.stringContaining(
-                // eslint-disable-next-line quotes
                 'src="https://www.youtube-nocookie.com/embed/9zcU6oUOHVc"',
             ),
         )
@@ -163,26 +150,15 @@ describe("transforms markdown", () => {
         )
 
         expect(html).toEqual(
-            expect.stringContaining(
-                // eslint-disable-next-line quotes
-                '<a href="https://example.com"',
-            ),
+            expect.stringContaining('<a href="https://example.com"'),
         )
 
         expect(html).toEqual(expect.stringContaining("external link</a>"))
 
         expect(html).toEqual(
-            expect.stringContaining(
-                // eslint-disable-next-line quotes
-                'rel="noopener noreferrer"',
-            ),
+            expect.stringContaining('rel="noopener noreferrer"'),
         )
 
-        expect(html).toEqual(
-            expect.stringContaining(
-                // eslint-disable-next-line quotes
-                'target="_blank"',
-            ),
-        )
+        expect(html).toEqual(expect.stringContaining('target="_blank"'))
     })
 })


### PR DESCRIPTION
Applies a bunch of simplifications to the file. I've commented them inline. The biggest one is using [`ts(eslint).config`](https://typescript-eslint.io/packages/typescript-eslint#config) to get types and flatten arrays.

Please forgive me if you already know a bunch of the comments 😅. I figured they'd be useful in case anybody is reading this.

I'm also not sure I'm not removing some rules that actually are intentional. Definitely not suggesting this should be 100% trusted!

💖 