### PR TITLE
🌑 shadow link

### DIFF
--- a/src/components/FancyLink/FancyLink.test.tsx
+++ b/src/components/FancyLink/FancyLink.test.tsx
@@ -5,5 +5,5 @@ import FancyLink from "~/components/FancyLink"
 
 test("renders", () => {
     render(<FancyLink to="/blog">blog</FancyLink>)
-    expect(screen.getByText("blog")).toHaveClass("shadow-link")
+    expect(screen.getByText("blog")).toHaveClass("underline")
 })

--- a/src/components/FancyLink/FancyLink.tsx
+++ b/src/components/FancyLink/FancyLink.tsx
@@ -9,7 +9,7 @@ type FancyLinkProps = {
 const FancyLink: FC<FancyLinkProps> = ({children, to}) => {
     return (
         <Link
-            className="shadow-link hover:shadow-link-hover transition duration-300"
+            className="underline decoration-purple-400 decoration-2 underline-offset-4 transition-colors duration-300 hover:decoration-purple-600 dark:hover:decoration-purple-300"
             to={to}
             prefetch="intent"
         >

--- a/src/components/Markdown/Markdown.tsx
+++ b/src/components/Markdown/Markdown.tsx
@@ -10,7 +10,7 @@ const Markdown: FC<MarkdownProps> = ({content, className}) => {
     return (
         <div
             className={classnames(
-                "prose-md prose-[iframe]:w-100 prose prose-purple dark:prose-invert prose-a:font-normal prose-a:text-gray-700 prose-a:no-underline prose-a:shadow-link prose-a:transition prose-a:duration-300 prose-a:hover:shadow-link-hover prose-code:rounded prose-code:bg-[#2d2b55] prose-code:px-2 prose-code:py-1 prose-code:font-normal prose-code:text-[#fad000] prose-code:before:content-none prose-code:after:content-none prose-pre:bg-[#2D2B55] prose-img:mx-auto prose-img:rounded dark:prose-a:text-gray-300 max-w-3xl",
+                "prose-md prose-[iframe]:w-100 prose prose-purple dark:prose-invert prose-a:font-normal prose-a:text-gray-700 prose-a:underline prose-a:decoration-purple-400 prose-a:decoration-2 prose-a:underline-offset-4 prose-a:transition-colors prose-a:duration-300 prose-a:hover:decoration-purple-600 dark:prose-a:text-gray-300 dark:prose-a:hover:decoration-purple-300 prose-code:rounded prose-code:bg-[#2d2b55] prose-code:px-2 prose-code:py-1 prose-code:font-normal prose-code:text-[#fad000] prose-code:before:content-none prose-code:after:content-none prose-pre:bg-[#2D2B55] prose-img:mx-auto prose-img:rounded max-w-3xl",
                 className,
             )}
         >

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -21,8 +21,6 @@
     --shadow-reverse-box: -3px 3px 0 #000;
     --shadow-box-white: 3px 3px 0 #fff;
     --shadow-reverse-box-white: -3px 3px 0 #fff;
-    --shadow-link: inset 0 -2px oklch(0.714 0.203 305.504);
-    --shadow-link-hover: inset 0 -25px 0 oklch(0.714 0.203 305.504);
 
     --grid-template-columns-hero: minmax(auto, 15.625rem) auto;
 


### PR DESCRIPTION
## Summary

- Replace FancyLink shadow styling with purple underlines and hover transitions
- Apply consistent underline styling to Markdown links in light and dark modes
- Remove obsolete link shadow theme variables
- Update the FancyLink test to verify underline styling

## Testing

- Updated the FancyLink component test to cover the new underline class